### PR TITLE
README - Remove slash prefix from /api

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When deploying to Azure, you will need to properly [configure your build](https:
 | property          | value          |
 | ----------------- | -------------- |
 | `app_location`    | `./`           |
-| `api_location`    | `/api`         |
+| `api_location`    | `api`         |
 | `output_location` | `build/static` |
 
 ## Running locally with the Azure SWA CLI


### PR DESCRIPTION
I'm using `api` instead of `/api` and everything seems to work properly. I also see that you don't use it in the demo, so why not remove the slash 🙂