### PR TITLE
Add immutable cache headers to hashed assets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-	"editor.formatOnSave": true
+	"editor.formatOnSave": true,
+	"[json]": {
+		"editor.formatOnSave": false
+	}
 }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ export default function ({ debug = false } = {}) {
 						route: '*',
 						methods: ['POST', 'PUT', 'DELETE'],
 						rewrite: ssrFunctionRoute
+					},
+					{
+						route: `/${builder.appDir}/*`,
+						headers: {
+							'cache-control': 'public, immutable, max-age=31536000'
+						}
 					}
 				],
 				navigationFallback: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
 			},
 			"devDependencies": {
 				"@azure/functions": "^1.2.3",
-				"@sveltejs/kit": "^1.0.0-next.211",
+				"@sveltejs/kit": "^1.0.0-next.218",
 				"@types/node": "^17.0.5",
 				"prettier": "^2.4.1"
 			},
 			"peerDependencies": {
-				"@sveltejs/kit": "^1.0.0-next.208"
+				"@sveltejs/kit": "^1.0.0-next.218"
 			}
 		},
 		"node_modules/@azure/functions": {
@@ -41,9 +41,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.211",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.211.tgz",
-			"integrity": "sha512-jS28R40H6BypK5rSVUzNmQW3NaBTFijj4fJPEtx8YeSLuzqm7ZGl3wwqF+FRxisP6oyz2GkYSARRxzemDOfn9A==",
+			"version": "1.0.0-next.218",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.218.tgz",
+			"integrity": "sha512-reimVgWaFq0qIvxkKnWE4nq35JFd6yQ6Lkge+o3WkX3hV8CAtrLbSAzFaEIUu5Ph09gJkl2PnqQa32WVDaeBZg==",
 			"dev": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
@@ -627,9 +627,9 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.211",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.211.tgz",
-			"integrity": "sha512-jS28R40H6BypK5rSVUzNmQW3NaBTFijj4fJPEtx8YeSLuzqm7ZGl3wwqF+FRxisP6oyz2GkYSARRxzemDOfn9A==",
+			"version": "1.0.0-next.218",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.218.tgz",
+			"integrity": "sha512-reimVgWaFq0qIvxkKnWE4nq35JFd6yQ6Lkge+o3WkX3hV8CAtrLbSAzFaEIUu5Ph09gJkl2PnqQa32WVDaeBZg==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
 		"url": "https://github.com/geoffrich/svelte-adapter-azure-swa/issues"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0-next.208"
+		"@sveltejs/kit": "^1.0.0-next.218"
 	},
 	"devDependencies": {
 		"@azure/functions": "^1.2.3",
-		"@sveltejs/kit": "^1.0.0-next.211",
+		"@sveltejs/kit": "^1.0.0-next.218",
 		"@types/node": "^17.0.5",
 		"prettier": "^2.4.1"
 	},


### PR DESCRIPTION
Same change as the one to official adapters in https://github.com/sveltejs/kit/pull/3222

Everything in the app directory (i.e. `/_app`) has a filename that includes a hash, and thus can have the immutable cache-control header.

Also bumps SvelteKit peer dependency to next-218, since we need the new `builder.appDir` property.