### PR TITLE
Render response as Uint8Array instead of text

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -65,7 +65,7 @@ function toRequest(context) {
  */
 async function toResponse(rendered) {
 	const { status } = rendered;
-	const resBody = await rendered.text();
+	const resBody = new Uint8Array(await rendered.arrayBuffer());
 
 	/** @type {Record<string, string>} */
 	const resHeaders = {};
@@ -76,6 +76,7 @@ async function toResponse(rendered) {
 	return {
 		status,
 		body: resBody,
-		headers: resHeaders
+		headers: resHeaders,
+		isRaw: true
 	};
 }


### PR DESCRIPTION
When I return a binary response from an endpoint, it is encoded as text by the adapter. This PR fixes that by returning the raw body from SvelteKit's response and setting isRaw in context.res to true. I think changing this for all responses is appropriate, since SvelteKit is already handling encoding for text content types.