### PR TITLE
Drop Node 14, handle polyfill breaking change, update immutable directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export default {
 };
 ```
 
-You will need to create an `api/` folder in your project root containing a [`host.json`](https://docs.microsoft.com/en-us/azure/azure-functions/functions-host-json) (see sample below). The adapter will output the `render` Azure function for SSR in that folder. The `api` folder needs to be in your repo so that Azure can recognize the API at build time. However, you can add `api/render` to your .gitignore so that the generated function is not in source control.
+You will need to create an `api/` folder in your project root containing a [`host.json`](https://docs.microsoft.com/en-us/azure/azure-functions/functions-host-json) and a `package.json` (see samples below). The adapter will output the `render` Azure function for SSR in that folder. The `api` folder needs to be in your repo so that Azure can recognize the API at build time. However, you can add `api/render` to your .gitignore so that the generated function is not in source control.
 
 ### Sample `host.json`
 
@@ -35,6 +35,14 @@ You will need to create an `api/` folder in your project root containing a [`hos
 		"version": "[2.*, 3.0.0)"
 	}
 }
+```
+
+### Sample `package.json`
+
+It's okay for this to be empty. Not including it causes the Azure Function build to fail.
+
+```json
+{}
 ```
 
 ## Azure configuration

--- a/files/api/package.json
+++ b/files/api/package.json
@@ -1,3 +1,0 @@
-{
-	"type": "commonjs"
-}

--- a/files/entry.js
+++ b/files/entry.js
@@ -1,11 +1,11 @@
-import { installFetch } from '@sveltejs/kit/install-fetch';
+import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
 
 // replaced at build time
 const debug = DEBUG;
 
-installFetch();
+installPolyfills();
 
 const server = new Server(manifest);
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,9 @@ export default function ({ debug = false, customStaticWebAppConfig = {} } = {}) 
 				],
 				navigationFallback: {
 					rewrite: ssrFunctionRoute
+				},
+				platform: {
+					apiRuntime: 'node:16'
 				}
 			};
 
@@ -99,7 +102,7 @@ export default function ({ debug = false, customStaticWebAppConfig = {} } = {}) 
 				outfile: join(apiDir, 'index.js'),
 				bundle: true,
 				platform: 'node',
-				target: 'node12'
+				target: 'node16'
 			};
 
 			await esbuild.build(default_options);

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ export default function ({ debug = false, customStaticWebAppConfig = {} } = {}) 
 						rewrite: ssrFunctionRoute
 					},
 					{
-						route: `/${builder.config.kit.appDir}/*`,
+						route: `/${builder.config.kit.appDir}/immutable/*`,
 						headers: {
 							'cache-control': 'public, immutable, max-age=31536000'
 						}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'fs';
+import { writeFileSync, existsSync } from 'fs';
 import { join, posix } from 'path';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
@@ -60,6 +60,12 @@ export default function ({ debug = false, customStaticWebAppConfig = {} } = {}) 
 					apiRuntime: 'node:16'
 				}
 			};
+
+			if (!existsSync(join('api', 'package.json'))) {
+				throw new Error(
+					'You need to create a package.json in your `api` directory. See the adapter README for details.'
+				);
+			}
 
 			const tmp = builder.getBuildDirectory('azure-tmp');
 			const publish = 'build';

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
 				"@types/node": "^17.0.5",
 				"prettier": "^2.4.1"
 			},
+			"engines": {
+				"node": ">=16.7"
+			},
 			"peerDependencies": {
 				"@sveltejs/kit": "^1.0.0-next.344"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
 			},
 			"devDependencies": {
 				"@azure/functions": "^1.2.3",
-				"@sveltejs/kit": "^1.0.0-next.292",
+				"@sveltejs/kit": "^1.0.0-next.344",
 				"@types/node": "^17.0.5",
 				"prettier": "^2.4.1"
 			},
 			"peerDependencies": {
-				"@sveltejs/kit": "^1.0.0-next.292"
+				"@sveltejs/kit": "^1.0.0-next.344"
 			}
 		},
 		"node_modules/@azure/functions": {
@@ -28,9 +28,9 @@
 			"dev": true
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
-			"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 			"dev": true,
 			"dependencies": {
 				"estree-walker": "^2.0.1",
@@ -41,37 +41,38 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.292",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.292.tgz",
-			"integrity": "sha512-sWLuN7/rOsV3xX0VtT562PXhGqkuU9np03Gv3k0v+MKh+NW59TUGgQTWIe0LP6ImHiZaMt0Uaw4oYfIn0wsTmQ==",
+			"version": "1.0.0-next.345",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.345.tgz",
+			"integrity": "sha512-2nLZoXZ02uXMSxqRAMRCr/J4aCphqgKLxEhRRyh3c3aWLAjWiDWLDcvSB770eHt3y0MkYrTvp7JrDF7RhfyuBA==",
 			"dev": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.44",
+				"chokidar": "^3.5.3",
 				"sade": "^1.7.4",
-				"vite": "^2.8.0"
+				"vite": "^2.9.9"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
 			},
 			"engines": {
-				"node": ">=14.13"
+				"node": ">=16.7"
 			},
 			"peerDependencies": {
 				"svelte": "^3.44.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.33",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.33.tgz",
-			"integrity": "sha512-aj0h2+ZixgT+yoJFIs8dRRw/Cj9tgNu3+hY4CJikpa04mfhR61wXqJFfi2ZEFMUvFda5nCxKYIChFkc6wq5fJA==",
+			"version": "1.0.0-next.44",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.44.tgz",
+			"integrity": "sha512-n+sssEWbzykPS447FmnNyU5GxEhrBPDVd0lxNZnxRGz9P6651LjjwAnISKr3CKgT9v8IybP8VD0n2i5XzbqExg==",
 			"dev": true,
 			"dependencies": {
-				"@rollup/pluginutils": "^4.1.2",
-				"debug": "^4.3.3",
+				"@rollup/pluginutils": "^4.2.1",
+				"debug": "^4.3.4",
+				"deepmerge": "^4.2.2",
 				"kleur": "^4.1.4",
-				"magic-string": "^0.25.7",
-				"require-relative": "^0.8.7",
-				"svelte-hmr": "^0.14.9"
+				"magic-string": "^0.26.1",
+				"svelte-hmr": "^0.14.11"
 			},
 			"engines": {
 				"node": "^14.13.1 || >= 16"
@@ -79,7 +80,7 @@
 			"peerDependencies": {
 				"diff-match-patch": "^1.0.5",
 				"svelte": "^3.44.0",
-				"vite": "^2.7.0"
+				"vite": "^2.9.0"
 			},
 			"peerDependenciesMeta": {
 				"diff-match-patch": {
@@ -93,10 +94,71 @@
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
 		},
+		"node_modules/anymatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"dev": true,
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/binary-extensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"dev": true,
+			"dependencies": {
+				"fill-range": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
 		"node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -108,6 +170,15 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/esbuild": {
@@ -136,6 +207,22 @@
 				"esbuild-windows-32": "0.13.15",
 				"esbuild-windows-64": "0.13.15",
 				"esbuild-windows-arm64": "0.13.15"
+			}
+		},
+		"node_modules/esbuild-android-64": {
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+			"integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/esbuild-android-arm64": {
@@ -271,9 +358,9 @@
 			]
 		},
 		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.23.tgz",
-			"integrity": "sha512-fbL3ggK2wY0D8I5raPIMPhpCvODFE+Bhb5QGtNP3r5aUsRR6TQV+ZBXIaw84iyvKC8vlXiA4fWLGhghAd/h/Zg==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+			"integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -287,9 +374,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.23.tgz",
-			"integrity": "sha512-GHMDCyfy7+FaNSO8RJ8KCFsnax8fLUsOrj9q5Gi2JmZMY0Zhp75keb5abTFCq2/Oy6KVcT0Dcbyo/bFb4rIFJA==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+			"integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
 			"cpu": [
 				"s390x"
 			],
@@ -380,6 +467,18 @@
 			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
 			"dev": true
 		},
+		"node_modules/fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"dev": true,
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -400,6 +499,18 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
+		"node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -412,16 +523,58 @@
 				"node": ">= 0.4.0"
 			}
 		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/kleur": {
@@ -434,12 +587,15 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
 			"dev": true,
 			"dependencies": {
-				"sourcemap-codec": "^1.4.4"
+				"sourcemap-codec": "^1.4.8"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/mri": {
@@ -458,15 +614,24 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-parse": {
@@ -482,9 +647,9 @@
 			"dev": true
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.6"
@@ -494,21 +659,27 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.7",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-			"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+			"version": "8.4.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				}
+			],
 			"dependencies": {
-				"nanoid": "^3.3.1",
+				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			}
 		},
 		"node_modules/prettier": {
@@ -523,11 +694,17 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/require-relative": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-			"dev": true
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
 		},
 		"node_modules/resolve": {
 			"version": "1.22.0",
@@ -547,9 +724,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.62.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.62.0.tgz",
-			"integrity": "sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.74.1.tgz",
+			"integrity": "sha512-K2zW7kV8Voua5eGkbnBtWYfMIhYhT9Pel2uhBk2WO5eMee161nPze/XRfvEQPFYz7KgrCCnmh2Wy0AMFLGGmMA==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -601,9 +778,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.44.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.3.tgz",
-			"integrity": "sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
+			"integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -611,22 +788,37 @@
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.14.9",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
-			"integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
+			"version": "0.14.11",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.11.tgz",
+			"integrity": "sha512-R9CVfX6DXxW1Kn45Jtmx+yUe+sPhrbYSUp7TkzbW0jI5fVPn6lsNG9NEs5dFg5qRhFNAoVdRw5qQDLALNKhwbQ==",
 			"dev": true,
+			"engines": {
+				"node": "^12.20 || ^14.13.1 || >= 16"
+			},
 			"peerDependencies": {
 				"svelte": ">=3.19.0"
 			}
 		},
-		"node_modules/vite": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.8.4.tgz",
-			"integrity": "sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==",
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.14.14",
-				"postcss": "^8.4.6",
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/vite": {
+			"version": "2.9.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
+			"integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+			"dev": true,
+			"dependencies": {
+				"esbuild": "^0.14.27",
+				"postcss": "^8.4.13",
 				"resolve": "^1.22.0",
 				"rollup": "^2.59.0"
 			},
@@ -657,9 +849,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.23.tgz",
-			"integrity": "sha512-XjnIcZ9KB6lfonCa+jRguXyRYcldmkyZ99ieDksqW/C8bnyEX299yA4QH2XcgijCgaddEZePPTgvx/2imsq7Ig==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+			"integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -669,31 +861,32 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"esbuild-android-arm64": "0.14.23",
-				"esbuild-darwin-64": "0.14.23",
-				"esbuild-darwin-arm64": "0.14.23",
-				"esbuild-freebsd-64": "0.14.23",
-				"esbuild-freebsd-arm64": "0.14.23",
-				"esbuild-linux-32": "0.14.23",
-				"esbuild-linux-64": "0.14.23",
-				"esbuild-linux-arm": "0.14.23",
-				"esbuild-linux-arm64": "0.14.23",
-				"esbuild-linux-mips64le": "0.14.23",
-				"esbuild-linux-ppc64le": "0.14.23",
-				"esbuild-linux-riscv64": "0.14.23",
-				"esbuild-linux-s390x": "0.14.23",
-				"esbuild-netbsd-64": "0.14.23",
-				"esbuild-openbsd-64": "0.14.23",
-				"esbuild-sunos-64": "0.14.23",
-				"esbuild-windows-32": "0.14.23",
-				"esbuild-windows-64": "0.14.23",
-				"esbuild-windows-arm64": "0.14.23"
+				"esbuild-android-64": "0.14.39",
+				"esbuild-android-arm64": "0.14.39",
+				"esbuild-darwin-64": "0.14.39",
+				"esbuild-darwin-arm64": "0.14.39",
+				"esbuild-freebsd-64": "0.14.39",
+				"esbuild-freebsd-arm64": "0.14.39",
+				"esbuild-linux-32": "0.14.39",
+				"esbuild-linux-64": "0.14.39",
+				"esbuild-linux-arm": "0.14.39",
+				"esbuild-linux-arm64": "0.14.39",
+				"esbuild-linux-mips64le": "0.14.39",
+				"esbuild-linux-ppc64le": "0.14.39",
+				"esbuild-linux-riscv64": "0.14.39",
+				"esbuild-linux-s390x": "0.14.39",
+				"esbuild-netbsd-64": "0.14.39",
+				"esbuild-openbsd-64": "0.14.39",
+				"esbuild-sunos-64": "0.14.39",
+				"esbuild-windows-32": "0.14.39",
+				"esbuild-windows-64": "0.14.39",
+				"esbuild-windows-arm64": "0.14.39"
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-android-arm64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.23.tgz",
-			"integrity": "sha512-k9sXem++mINrZty1v4FVt6nC5BQCFG4K2geCIUUqHNlTdFnuvcqsY7prcKZLFhqVC1rbcJAr9VSUGFL/vD4vsw==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+			"integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
 			"cpu": [
 				"arm64"
 			],
@@ -707,9 +900,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-darwin-64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.23.tgz",
-			"integrity": "sha512-lB0XRbtOYYL1tLcYw8BoBaYsFYiR48RPrA0KfA/7RFTr4MV7Bwy/J4+7nLsVnv9FGuQummM3uJ93J3ptaTqFug==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+			"integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
 			"cpu": [
 				"x64"
 			],
@@ -723,9 +916,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.23.tgz",
-			"integrity": "sha512-yat73Z/uJ5tRcfRiI4CCTv0FSnwErm3BJQeZAh+1tIP0TUNh6o+mXg338Zl5EKChD+YGp6PN+Dbhs7qa34RxSw==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+			"integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
 			"cpu": [
 				"arm64"
 			],
@@ -739,9 +932,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-freebsd-64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.23.tgz",
-			"integrity": "sha512-/1xiTjoLuQ+LlbfjJdKkX45qK/M7ARrbLmyf7x3JhyQGMjcxRYVR6Dw81uH3qlMHwT4cfLW4aEVBhP1aNV7VsA==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+			"integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
 			"cpu": [
 				"x64"
 			],
@@ -755,9 +948,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.23.tgz",
-			"integrity": "sha512-uyPqBU/Zcp6yEAZS4LKj5jEE0q2s4HmlMBIPzbW6cTunZ8cyvjG6YWpIZXb1KK3KTJDe62ltCrk3VzmWHp+iLg==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+			"integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
 			"cpu": [
 				"arm64"
 			],
@@ -771,9 +964,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-linux-32": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.23.tgz",
-			"integrity": "sha512-37R/WMkQyUfNhbH7aJrr1uCjDVdnPeTHGeDhZPUNhfoHV0lQuZNCKuNnDvlH/u/nwIYZNdVvz1Igv5rY/zfrzQ==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+			"integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
 			"cpu": [
 				"ia32"
 			],
@@ -787,9 +980,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-linux-64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.23.tgz",
-			"integrity": "sha512-H0gztDP60qqr8zoFhAO64waoN5yBXkmYCElFklpd6LPoobtNGNnDe99xOQm28+fuD75YJ7GKHzp/MLCLhw2+vQ==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+			"integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
 			"cpu": [
 				"x64"
 			],
@@ -803,9 +996,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-linux-arm": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.23.tgz",
-			"integrity": "sha512-x64CEUxi8+EzOAIpCUeuni0bZfzPw/65r8tC5cy5zOq9dY7ysOi5EVQHnzaxS+1NmV+/RVRpmrzGw1QgY2Xpmw==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+			"integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
 			"cpu": [
 				"arm"
 			],
@@ -819,9 +1012,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-linux-arm64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.23.tgz",
-			"integrity": "sha512-c4MLOIByNHR55n3KoYf9hYDfBRghMjOiHLaoYLhkQkIabb452RWi+HsNgB41sUpSlOAqfpqKPFNg7VrxL3UX9g==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+			"integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -835,9 +1028,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.23.tgz",
-			"integrity": "sha512-kHKyKRIAedYhKug2EJpyJxOUj3VYuamOVA1pY7EimoFPzaF3NeY7e4cFBAISC/Av0/tiV0xlFCt9q0HJ68IBIw==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+			"integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -851,9 +1044,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.23.tgz",
-			"integrity": "sha512-7ilAiJEPuJJnJp/LiDO0oJm5ygbBPzhchJJh9HsHZzeqO+3PUzItXi+8PuicY08r0AaaOe25LA7sGJ0MzbfBag==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+			"integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -867,9 +1060,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-netbsd-64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.23.tgz",
-			"integrity": "sha512-ovk2EX+3rrO1M2lowJfgMb/JPN1VwVYrx0QPUyudxkxLYrWeBxDKQvc6ffO+kB4QlDyTfdtAURrVzu3JeNdA2g==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+			"integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
 			"cpu": [
 				"x64"
 			],
@@ -883,9 +1076,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-openbsd-64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.23.tgz",
-			"integrity": "sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+			"integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
 			"cpu": [
 				"x64"
 			],
@@ -899,9 +1092,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-sunos-64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.23.tgz",
-			"integrity": "sha512-hAzeBeET0+SbScknPzS2LBY6FVDpgE+CsHSpe6CEoR51PApdn2IB0SyJX7vGelXzlyrnorM4CAsRyb9Qev4h9g==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+			"integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
 			"cpu": [
 				"x64"
 			],
@@ -915,9 +1108,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-windows-32": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.23.tgz",
-			"integrity": "sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+			"integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -931,9 +1124,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-windows-64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.23.tgz",
-			"integrity": "sha512-JtIT0t8ymkpl6YlmOl6zoSWL5cnCgyLaBdf/SiU/Eg3C13r0NbHZWNT/RDEMKK91Y6t79kTs3vyRcNZbfu5a8g==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+			"integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
 			"cpu": [
 				"x64"
 			],
@@ -947,9 +1140,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/esbuild-windows-arm64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.23.tgz",
-			"integrity": "sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+			"integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
 			"cpu": [
 				"arm64"
 			],
@@ -971,9 +1164,9 @@
 			"dev": true
 		},
 		"@rollup/pluginutils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
-			"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 			"dev": true,
 			"requires": {
 				"estree-walker": "^2.0.1",
@@ -981,28 +1174,29 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.292",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.292.tgz",
-			"integrity": "sha512-sWLuN7/rOsV3xX0VtT562PXhGqkuU9np03Gv3k0v+MKh+NW59TUGgQTWIe0LP6ImHiZaMt0Uaw4oYfIn0wsTmQ==",
+			"version": "1.0.0-next.345",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.345.tgz",
+			"integrity": "sha512-2nLZoXZ02uXMSxqRAMRCr/J4aCphqgKLxEhRRyh3c3aWLAjWiDWLDcvSB770eHt3y0MkYrTvp7JrDF7RhfyuBA==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.44",
+				"chokidar": "^3.5.3",
 				"sade": "^1.7.4",
-				"vite": "^2.8.0"
+				"vite": "^2.9.9"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.33",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.33.tgz",
-			"integrity": "sha512-aj0h2+ZixgT+yoJFIs8dRRw/Cj9tgNu3+hY4CJikpa04mfhR61wXqJFfi2ZEFMUvFda5nCxKYIChFkc6wq5fJA==",
+			"version": "1.0.0-next.44",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.44.tgz",
+			"integrity": "sha512-n+sssEWbzykPS447FmnNyU5GxEhrBPDVd0lxNZnxRGz9P6651LjjwAnISKr3CKgT9v8IybP8VD0n2i5XzbqExg==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^4.1.2",
-				"debug": "^4.3.3",
+				"@rollup/pluginutils": "^4.2.1",
+				"debug": "^4.3.4",
+				"deepmerge": "^4.2.2",
 				"kleur": "^4.1.4",
-				"magic-string": "^0.25.7",
-				"require-relative": "^0.8.7",
-				"svelte-hmr": "^0.14.9"
+				"magic-string": "^0.26.1",
+				"svelte-hmr": "^0.14.11"
 			}
 		},
 		"@types/node": {
@@ -1011,14 +1205,61 @@
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
 		},
+		"anymatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"dev": true,
+			"requires": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			}
+		},
+		"binary-extensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"dev": true
+		},
+		"braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"dev": true,
+			"requires": {
+				"fill-range": "^7.0.1"
+			}
+		},
+		"chokidar": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+			"dev": true,
+			"requires": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"fsevents": "~2.3.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			}
+		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
 			}
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
 		},
 		"esbuild": {
 			"version": "0.13.15",
@@ -1043,6 +1284,13 @@
 				"esbuild-windows-64": "0.13.15",
 				"esbuild-windows-arm64": "0.13.15"
 			}
+		},
+		"esbuild-android-64": {
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+			"integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
+			"dev": true,
+			"optional": true
 		},
 		"esbuild-android-arm64": {
 			"version": "0.13.15",
@@ -1111,16 +1359,16 @@
 			"optional": true
 		},
 		"esbuild-linux-riscv64": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.23.tgz",
-			"integrity": "sha512-fbL3ggK2wY0D8I5raPIMPhpCvODFE+Bhb5QGtNP3r5aUsRR6TQV+ZBXIaw84iyvKC8vlXiA4fWLGhghAd/h/Zg==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+			"integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-s390x": {
-			"version": "0.14.23",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.23.tgz",
-			"integrity": "sha512-GHMDCyfy7+FaNSO8RJ8KCFsnax8fLUsOrj9q5Gi2JmZMY0Zhp75keb5abTFCq2/Oy6KVcT0Dcbyo/bFb4rIFJA==",
+			"version": "0.14.39",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+			"integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
 			"dev": true,
 			"optional": true
 		},
@@ -1166,6 +1414,15 @@
 			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
 			"dev": true
 		},
+		"fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"dev": true,
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
+		},
 		"fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1179,6 +1436,15 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
+		"glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"requires": {
+				"is-glob": "^4.0.1"
+			}
+		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1188,14 +1454,44 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "^2.0.0"
+			}
+		},
 		"is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
 			}
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
 		},
 		"kleur": {
 			"version": "4.1.4",
@@ -1204,12 +1500,12 @@
 			"dev": true
 		},
 		"magic-string": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
 			"dev": true,
 			"requires": {
-				"sourcemap-codec": "^1.4.4"
+				"sourcemap-codec": "^1.4.8"
 			}
 		},
 		"mri": {
@@ -1225,9 +1521,15 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"dev": true
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
 		},
 		"path-parse": {
@@ -1243,18 +1545,18 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.7",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-			"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+			"version": "8.4.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.3.1",
+				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -1265,11 +1567,14 @@
 			"integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
 			"dev": true
 		},
-		"require-relative": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-			"dev": true
+		"readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"requires": {
+				"picomatch": "^2.2.1"
+			}
 		},
 		"resolve": {
 			"version": "1.22.0",
@@ -1283,9 +1588,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.62.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.62.0.tgz",
-			"integrity": "sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.74.1.tgz",
+			"integrity": "sha512-K2zW7kV8Voua5eGkbnBtWYfMIhYhT9Pel2uhBk2WO5eMee161nPze/XRfvEQPFYz7KgrCCnmh2Wy0AMFLGGmMA==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -1319,175 +1624,185 @@
 			"dev": true
 		},
 		"svelte": {
-			"version": "3.44.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.3.tgz",
-			"integrity": "sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
+			"integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
 			"dev": true,
 			"peer": true
 		},
 		"svelte-hmr": {
-			"version": "0.14.9",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
-			"integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
+			"version": "0.14.11",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.11.tgz",
+			"integrity": "sha512-R9CVfX6DXxW1Kn45Jtmx+yUe+sPhrbYSUp7TkzbW0jI5fVPn6lsNG9NEs5dFg5qRhFNAoVdRw5qQDLALNKhwbQ==",
 			"dev": true,
 			"requires": {}
 		},
-		"vite": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.8.4.tgz",
-			"integrity": "sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==",
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.14.14",
+				"is-number": "^7.0.0"
+			}
+		},
+		"vite": {
+			"version": "2.9.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
+			"integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+			"dev": true,
+			"requires": {
+				"esbuild": "^0.14.27",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.6",
+				"postcss": "^8.4.13",
 				"resolve": "^1.22.0",
 				"rollup": "^2.59.0"
 			},
 			"dependencies": {
 				"esbuild": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.23.tgz",
-					"integrity": "sha512-XjnIcZ9KB6lfonCa+jRguXyRYcldmkyZ99ieDksqW/C8bnyEX299yA4QH2XcgijCgaddEZePPTgvx/2imsq7Ig==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+					"integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
 					"dev": true,
 					"requires": {
-						"esbuild-android-arm64": "0.14.23",
-						"esbuild-darwin-64": "0.14.23",
-						"esbuild-darwin-arm64": "0.14.23",
-						"esbuild-freebsd-64": "0.14.23",
-						"esbuild-freebsd-arm64": "0.14.23",
-						"esbuild-linux-32": "0.14.23",
-						"esbuild-linux-64": "0.14.23",
-						"esbuild-linux-arm": "0.14.23",
-						"esbuild-linux-arm64": "0.14.23",
-						"esbuild-linux-mips64le": "0.14.23",
-						"esbuild-linux-ppc64le": "0.14.23",
-						"esbuild-linux-riscv64": "0.14.23",
-						"esbuild-linux-s390x": "0.14.23",
-						"esbuild-netbsd-64": "0.14.23",
-						"esbuild-openbsd-64": "0.14.23",
-						"esbuild-sunos-64": "0.14.23",
-						"esbuild-windows-32": "0.14.23",
-						"esbuild-windows-64": "0.14.23",
-						"esbuild-windows-arm64": "0.14.23"
+						"esbuild-android-64": "0.14.39",
+						"esbuild-android-arm64": "0.14.39",
+						"esbuild-darwin-64": "0.14.39",
+						"esbuild-darwin-arm64": "0.14.39",
+						"esbuild-freebsd-64": "0.14.39",
+						"esbuild-freebsd-arm64": "0.14.39",
+						"esbuild-linux-32": "0.14.39",
+						"esbuild-linux-64": "0.14.39",
+						"esbuild-linux-arm": "0.14.39",
+						"esbuild-linux-arm64": "0.14.39",
+						"esbuild-linux-mips64le": "0.14.39",
+						"esbuild-linux-ppc64le": "0.14.39",
+						"esbuild-linux-riscv64": "0.14.39",
+						"esbuild-linux-s390x": "0.14.39",
+						"esbuild-netbsd-64": "0.14.39",
+						"esbuild-openbsd-64": "0.14.39",
+						"esbuild-sunos-64": "0.14.39",
+						"esbuild-windows-32": "0.14.39",
+						"esbuild-windows-64": "0.14.39",
+						"esbuild-windows-arm64": "0.14.39"
 					}
 				},
 				"esbuild-android-arm64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.23.tgz",
-					"integrity": "sha512-k9sXem++mINrZty1v4FVt6nC5BQCFG4K2geCIUUqHNlTdFnuvcqsY7prcKZLFhqVC1rbcJAr9VSUGFL/vD4vsw==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+					"integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-darwin-64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.23.tgz",
-					"integrity": "sha512-lB0XRbtOYYL1tLcYw8BoBaYsFYiR48RPrA0KfA/7RFTr4MV7Bwy/J4+7nLsVnv9FGuQummM3uJ93J3ptaTqFug==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+					"integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-darwin-arm64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.23.tgz",
-					"integrity": "sha512-yat73Z/uJ5tRcfRiI4CCTv0FSnwErm3BJQeZAh+1tIP0TUNh6o+mXg338Zl5EKChD+YGp6PN+Dbhs7qa34RxSw==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+					"integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-freebsd-64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.23.tgz",
-					"integrity": "sha512-/1xiTjoLuQ+LlbfjJdKkX45qK/M7ARrbLmyf7x3JhyQGMjcxRYVR6Dw81uH3qlMHwT4cfLW4aEVBhP1aNV7VsA==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+					"integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-freebsd-arm64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.23.tgz",
-					"integrity": "sha512-uyPqBU/Zcp6yEAZS4LKj5jEE0q2s4HmlMBIPzbW6cTunZ8cyvjG6YWpIZXb1KK3KTJDe62ltCrk3VzmWHp+iLg==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+					"integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-linux-32": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.23.tgz",
-					"integrity": "sha512-37R/WMkQyUfNhbH7aJrr1uCjDVdnPeTHGeDhZPUNhfoHV0lQuZNCKuNnDvlH/u/nwIYZNdVvz1Igv5rY/zfrzQ==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+					"integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-linux-64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.23.tgz",
-					"integrity": "sha512-H0gztDP60qqr8zoFhAO64waoN5yBXkmYCElFklpd6LPoobtNGNnDe99xOQm28+fuD75YJ7GKHzp/MLCLhw2+vQ==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+					"integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-linux-arm": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.23.tgz",
-					"integrity": "sha512-x64CEUxi8+EzOAIpCUeuni0bZfzPw/65r8tC5cy5zOq9dY7ysOi5EVQHnzaxS+1NmV+/RVRpmrzGw1QgY2Xpmw==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+					"integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-linux-arm64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.23.tgz",
-					"integrity": "sha512-c4MLOIByNHR55n3KoYf9hYDfBRghMjOiHLaoYLhkQkIabb452RWi+HsNgB41sUpSlOAqfpqKPFNg7VrxL3UX9g==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+					"integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-linux-mips64le": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.23.tgz",
-					"integrity": "sha512-kHKyKRIAedYhKug2EJpyJxOUj3VYuamOVA1pY7EimoFPzaF3NeY7e4cFBAISC/Av0/tiV0xlFCt9q0HJ68IBIw==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+					"integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-linux-ppc64le": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.23.tgz",
-					"integrity": "sha512-7ilAiJEPuJJnJp/LiDO0oJm5ygbBPzhchJJh9HsHZzeqO+3PUzItXi+8PuicY08r0AaaOe25LA7sGJ0MzbfBag==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+					"integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-netbsd-64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.23.tgz",
-					"integrity": "sha512-ovk2EX+3rrO1M2lowJfgMb/JPN1VwVYrx0QPUyudxkxLYrWeBxDKQvc6ffO+kB4QlDyTfdtAURrVzu3JeNdA2g==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+					"integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-openbsd-64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.23.tgz",
-					"integrity": "sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+					"integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-sunos-64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.23.tgz",
-					"integrity": "sha512-hAzeBeET0+SbScknPzS2LBY6FVDpgE+CsHSpe6CEoR51PApdn2IB0SyJX7vGelXzlyrnorM4CAsRyb9Qev4h9g==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+					"integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-windows-32": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.23.tgz",
-					"integrity": "sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+					"integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-windows-64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.23.tgz",
-					"integrity": "sha512-JtIT0t8ymkpl6YlmOl6zoSWL5cnCgyLaBdf/SiU/Eg3C13r0NbHZWNT/RDEMKK91Y6t79kTs3vyRcNZbfu5a8g==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+					"integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
 					"dev": true,
 					"optional": true
 				},
 				"esbuild-windows-arm64": {
-					"version": "0.14.23",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.23.tgz",
-					"integrity": "sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==",
+					"version": "0.14.39",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+					"integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
 					"dev": true,
 					"optional": true
 				}

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
 		"url": "https://github.com/geoffrich/svelte-adapter-azure-swa/issues"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0-next.292"
+		"@sveltejs/kit": "^1.0.0-next.344"
 	},
 	"devDependencies": {
 		"@azure/functions": "^1.2.3",
-		"@sveltejs/kit": "^1.0.0-next.292",
+		"@sveltejs/kit": "^1.0.0-next.344",
 		"@types/node": "^17.0.5",
 		"prettier": "^2.4.1"
 	},

--- a/types/swa.d.ts
+++ b/types/swa.d.ts
@@ -5,6 +5,7 @@ export interface StaticWebAppConfig {
 	globalHeaders?: Record<string, string>;
 	responseOverrides?: Record<OverridableResponseCodes, ResponseOverride>;
 	mimeTypes?: Record<string, string>;
+	platform?: Platform;
 }
 
 export type CustomStaticWebAppConfig = Omit<StaticWebAppConfig, 'navigationFallback'>;
@@ -42,3 +43,7 @@ export interface ResponseOverride {
 }
 
 export type OverridableResponseCodes = '400' | '401' | '403' | '404';
+
+export interface Platform {
+	apiRuntime: string;
+}


### PR DESCRIPTION
Fixes #44
Fixes #45
Fixes #12

This PR handles several recent SvelteKit breaking changes. 

- Target Node 16 using the `apiRuntime` SWA setting. With this change, you now need to have a package.json inside your `api/` directory. Without it, the function app will not build. The adapter will throw an error if this file is not present.
- Use new SvelteKit polyfill package
- Only mark files in `/_app/immutable` as immutable. 