### PR TITLE
Add the ability to extend esbuild options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default {
 
 ### esbuildOptions
 
-An object containing additional [Esbuild options](https://esbuild.github.io/api/#build-api). Currently supports: [external](https://esbuild.github.io/api/#external) and [keepNames](https://esbuild.github.io/api/#keep-names). 
+An object containing additional [Esbuild options](https://esbuild.github.io/api/#build-api). Currently only supports [external](https://esbuild.github.io/api/#external). 
 
 
 ```js
@@ -131,8 +131,7 @@ export default {
 		...
 		adapter: azure({
 			esbuildOptions: {
-				external: ['fsevents'],
-				keepNames: true
+				external: ['fsevents']
 			}
 		})
 	}

--- a/README.md
+++ b/README.md
@@ -117,3 +117,24 @@ export default {
 	}
 };
 ```
+
+### esbuildOptions
+
+An object containing additional [Esbuild options](https://esbuild.github.io/api/#build-api). Currently supports: [external](https://esbuild.github.io/api/#external) and [keepNames](https://esbuild.github.io/api/#keep-names). 
+
+
+```js
+import azure from 'svelte-adapter-azure-swa';
+
+export default {
+	kit: {
+		...
+		adapter: azure({
+			esbuildOptions: {
+				external: ['fsevents'],
+				keepNames: true
+			}
+		})
+	}
+};
+```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default {
 
 ### esbuildOptions
 
-An object containing additional [Esbuild options](https://esbuild.github.io/api/#build-api). Currently only supports [external](https://esbuild.github.io/api/#external). 
+An object containing additional [esbuild options](https://esbuild.github.io/api/#build-api). Currently only supports [external](https://esbuild.github.io/api/#external). If you require additional options to be exposed, plese [open an issue](https://github.com/geoffrich/svelte-adapter-azure-swa/issues).
 
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import esbuild from 'esbuild';
 type Options = {
 	debug?: boolean;
 	customStaticWebAppConfig?: CustomStaticWebAppConfig;
-	esbuildOptions?: esbuild.BuildOptions;
+	esbuildOptions?: Pick<esbuild.BuildOptions, 'external' | 'keepNames'>;
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,11 @@
 import { Adapter } from '@sveltejs/kit';
 import { CustomStaticWebAppConfig } from './types/swa';
+import esbuild from 'esbuild';
 
 type Options = {
 	debug?: boolean;
 	customStaticWebAppConfig?: CustomStaticWebAppConfig;
+	esbuildOptions?: esbuild.BuildOptions;
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import esbuild from 'esbuild';
 type Options = {
 	debug?: boolean;
 	customStaticWebAppConfig?: CustomStaticWebAppConfig;
-	esbuildOptions?: Pick<esbuild.BuildOptions, 'external' | 'keepNames'>;
+	esbuildOptions?: Pick<esbuild.BuildOptions, 'external'>;
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/index.js
+++ b/index.js
@@ -113,7 +113,6 @@ export default function ({
 				bundle: true,
 				platform: 'node',
 				target: 'node16',
-				keepNames: esbuildOptions.keepNames,
 				external: esbuildOptions.external
 			};
 

--- a/index.js
+++ b/index.js
@@ -108,12 +108,13 @@ export default function ({
 
 			/** @type {BuildOptions} */
 			const default_options = {
-				...esbuildOptions,
 				entryPoints: [entry],
 				outfile: join(apiDir, 'index.js'),
 				bundle: true,
 				platform: 'node',
-				target: 'node16'
+				target: 'node16',
+				keepNames: esbuildOptions.keepNames,
+				external: esbuildOptions.external
 			};
 
 			await esbuild.build(default_options);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,11 @@ function validateCustomConfig(config) {
 }
 
 /** @type {import('.').default} */
-export default function ({ debug = false, customStaticWebAppConfig = {} } = {}) {
+export default function ({
+	debug = false,
+	customStaticWebAppConfig = {},
+	esbuildOptions = {}
+} = {}) {
 	return {
 		name: 'adapter-azure-swa',
 
@@ -104,6 +108,7 @@ export default function ({ debug = false, customStaticWebAppConfig = {} } = {}) 
 
 			/** @type {BuildOptions} */
 			const default_options = {
+				...esbuildOptions,
 				entryPoints: [entry],
 				outfile: join(apiDir, 'index.js'),
 				bundle: true,


### PR DESCRIPTION
From reading some other issues, it sounds like you may be planning to remove esbuild all together. However, in the meantime, I keep running into scenarios that require some specific esbuild options (such as `external`). This PR allows you to add to the default options:

```
adapter: azure({
	esbuildOptions: {
		external: [
			'pg-native'
		]
	}
})
```