### PR TITLE
feat: remove call to writeStatic

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,6 @@ export default function ({ debug = false, customStaticWebAppConfig = {} } = {}) 
 			await esbuild.build(default_options);
 
 			builder.log.minor('Copying assets...');
-			builder.writeStatic(staticDir);
 			builder.writeClient(staticDir);
 			builder.writePrerendered(staticDir);
 


### PR DESCRIPTION
writeStatic has been removed from the adapter API

See https://github.com/sveltejs/kit/pull/5618

fixes #52