### PR TITLE
Update example swa-cli.config.json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To run the CLI, install `@azure/static-web-apps-cli` and the [Azure Functions Co
 {
 	"configurations": {
 		"app": {
-			"context": "./build/static",
+			"outputLocation": "./build/static",
 			"apiLocation": "./api"
 		}
 	}


### PR DESCRIPTION
context option seems to be [deprecated](https://azure.github.io/static-web-apps-cli/docs/cli/swa-config) seems like it was replaced with the outputLocation option. Tested on my environment and it works.