### PR TITLE
Fixes #63 Multiple Set-Cookie not working

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -1,7 +1,7 @@
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
-import * as set_cookie_parser from 'set-cookie-parser';
+import { split_cookies_from_headers } from './headers';
 
 // replaced at build time
 const debug = DEBUG;
@@ -68,25 +68,13 @@ async function toResponse(rendered) {
 	const { status } = rendered;
 	const resBody = new Uint8Array(await rendered.arrayBuffer());
 
-	/** @type {Record<string, string>} */
-	const resHeaders = {};
-
-	const resCookies = [];
-
-	rendered.headers.forEach((value, key) => {
-		if (key === 'set-cookie') {
-			const cookieStrings = set_cookie_parser.splitCookiesString(value);
-			resCookies.push(...set_cookie_parser.parse(cookieStrings));
-		} else {
-			resHeaders[key] = value;
-		}
-	});
+	const { headers, cookies } = split_cookies_from_headers(rendered.headers);
 
 	return {
 		status,
 		body: resBody,
-		headers: resHeaders,
-		cookies: resCookies,
+		headers,
+		cookies,
 		isRaw: true
 	};
 }

--- a/files/entry.js
+++ b/files/entry.js
@@ -1,7 +1,7 @@
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
-import { split_cookies_from_headers } from './headers';
+import { splitCookiesFromHeaders } from './headers';
 
 // replaced at build time
 const debug = DEBUG;
@@ -68,7 +68,7 @@ async function toResponse(rendered) {
 	const { status } = rendered;
 	const resBody = new Uint8Array(await rendered.arrayBuffer());
 
-	const { headers, cookies } = split_cookies_from_headers(rendered.headers);
+	const { headers, cookies } = splitCookiesFromHeaders(rendered.headers);
 
 	return {
 		status,

--- a/files/entry.js
+++ b/files/entry.js
@@ -1,6 +1,7 @@
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
+import * as set_cookie_parser from 'set-cookie-parser';
 
 // replaced at build time
 const debug = DEBUG;
@@ -69,14 +70,23 @@ async function toResponse(rendered) {
 
 	/** @type {Record<string, string>} */
 	const resHeaders = {};
+
+	const resCookies = [];
+
 	rendered.headers.forEach((value, key) => {
-		resHeaders[key] = value;
+		if (key === 'set-cookie') {
+			const cookieStrings = set_cookie_parser.splitCookiesString(value);
+			resCookies.push(...set_cookie_parser.parse(cookieStrings));
+		} else {
+			resHeaders[key] = value;
+		}
 	});
 
 	return {
 		status,
 		body: resBody,
 		headers: resHeaders,
+		cookies: resCookies,
 		isRaw: true
 	};
 }

--- a/files/headers.js
+++ b/files/headers.js
@@ -8,7 +8,7 @@ import * as set_cookie_parser from 'set-cookie-parser';
  *   cookies: set_cookie_parser.Cookie[]
  * }}
  */
-export function split_cookies_from_headers(headers) {
+export function splitCookiesFromHeaders(headers) {
 	/** @type {Record<string, string>} */
 	const resHeaders = {};
 

--- a/files/headers.js
+++ b/files/headers.js
@@ -1,0 +1,28 @@
+import * as set_cookie_parser from 'set-cookie-parser';
+
+/**
+ * Splits 'set-cookie' headers into individual cookies
+ * @param {Headers} headers
+ * @returns {{
+ *   headers: Record<string, string>,
+ *   cookies: set_cookie_parser.Cookie[]
+ * }}
+ */
+export function split_cookies_from_headers(headers) {
+	/** @type {Record<string, string>} */
+	const resHeaders = {};
+
+	/** @type {set_cookie_parser.Cookie[]} */
+	const resCookies = [];
+
+	headers.forEach((value, key) => {
+		if (key === 'set-cookie') {
+			const cookieStrings = set_cookie_parser.splitCookiesString(value);
+			resCookies.push(...set_cookie_parser.parse(cookieStrings));
+		} else {
+			resHeaders[key] = value;
+		}
+	});
+
+	return { headers: resHeaders, cookies: resCookies };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
 			"version": "0.10.0",
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.13.4"
+				"esbuild": "^0.13.4",
+				"set-cookie-parser": "^2.5.1"
 			},
 			"devDependencies": {
 				"@azure/functions": "^1.2.3",
 				"@sveltejs/kit": "^1.0.0-next.395",
 				"@types/node": "^17.0.5",
+				"@types/set-cookie-parser": "^2.4.2",
 				"@vitest/coverage-c8": "^0.23.4",
 				"prettier": "^2.4.1",
 				"vitest": "^0.23.4"
@@ -172,6 +174,15 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
+		},
+		"node_modules/@types/set-cookie-parser": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+			"integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@vitest/coverage-c8": {
 			"version": "0.23.4",
@@ -1357,8 +1368,7 @@
 		"node_modules/set-cookie-parser": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
-			"dev": true
+			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -2203,6 +2213,15 @@
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
 		},
+		"@types/set-cookie-parser": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+			"integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@vitest/coverage-c8": {
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.23.4.tgz",
@@ -2986,8 +3005,7 @@
 		"set-cookie-parser": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
-			"dev": true
+			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
 		},
 		"shebang-command": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
 		"@azure/functions": "^1.2.3",
 		"@sveltejs/kit": "^1.0.0-next.395",
 		"@types/node": "^17.0.5",
+		"@types/set-cookie-parser": "^2.4.2",
 		"@vitest/coverage-c8": "^0.23.4",
 		"prettier": "^2.4.1",
 		"vitest": "^0.23.4"
 	},
 	"dependencies": {
-		"esbuild": "^0.13.4"
+		"esbuild": "^0.13.4",
+		"set-cookie-parser": "^2.5.1"
 	},
 	"files": [
 		"files",

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -1,0 +1,59 @@
+import { installPolyfills } from '@sveltejs/kit/node/polyfills';
+import { expect, describe, test } from 'vitest';
+import { split_cookies_from_headers } from '../files/headers';
+
+installPolyfills();
+
+describe('header processing', () => {
+	test('no cookies', () => {
+		const headers = new Headers();
+		headers.append('Location', '/');
+		headers.append('Content-Type', 'application/json');
+
+		const cookies = split_cookies_from_headers(headers);
+
+		expect(cookies).toEqual({
+			cookies: [],
+			headers: {
+				'content-type': 'application/json',
+				location: '/'
+			}
+		});
+	});
+
+	test('multiple cookies', () => {
+		const headers = new Headers();
+
+		// https://httpwg.org/specs/rfc7231.html#http.date
+		const exp1 = 'Sun, 06 Nov 1994 08:49:37 GMT';
+		const exp2 = 'Sunday, 06-Nov-94 08:49:37 GMT';
+		const exp3 = 'Sun Nov  6 08:49:37 1994';
+
+		headers.append('Set-Cookie', `key1=val1; Expires=${exp1}`);
+		headers.append('Set-Cookie', `key2=val2; Expires=${exp2}`);
+		headers.append('Set-Cookie', `key3=val3; Expires=${exp3}`);
+
+		const cookies = split_cookies_from_headers(headers);
+
+		expect(cookies).toStrictEqual({
+			headers: {},
+			cookies: [
+				{
+					expires: new Date('1994-11-06T08:49:37.000Z'),
+					name: 'key1',
+					value: 'val1'
+				},
+				{
+					expires: new Date('1994-11-06T08:49:37.000Z'),
+					name: 'key2',
+					value: 'val2'
+				},
+				{
+					expires: new Date('1994-11-06T13:49:37.000Z'),
+					name: 'key3',
+					value: 'val3'
+				}
+			]
+		});
+	});
+});

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -27,7 +27,7 @@ describe('header processing', () => {
 		// https://httpwg.org/specs/rfc7231.html#http.date
 		const exp1 = 'Sun, 06 Nov 1994 08:49:37 GMT';
 		const exp2 = 'Sunday, 06-Nov-94 08:49:37 GMT';
-		const exp3 = 'Sun Nov  6 08:49:37 1994';
+		const exp3 = 'Sun Nov  6 08:49:37 1994 GMT';
 
 		headers.append('Set-Cookie', `key1=val1; Expires=${exp1}`);
 		headers.append('Set-Cookie', `key2=val2; Expires=${exp2}`);
@@ -49,7 +49,7 @@ describe('header processing', () => {
 					value: 'val2'
 				},
 				{
-					expires: new Date('1994-11-06T13:49:37.000Z'),
+					expires: new Date('1994-11-06T08:49:37.000Z'),
 					name: 'key3',
 					value: 'val3'
 				}

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -1,6 +1,6 @@
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { expect, describe, test } from 'vitest';
-import { split_cookies_from_headers } from '../files/headers';
+import { splitCookiesFromHeaders } from '../files/headers';
 
 installPolyfills();
 
@@ -10,7 +10,7 @@ describe('header processing', () => {
 		headers.append('Location', '/');
 		headers.append('Content-Type', 'application/json');
 
-		const cookies = split_cookies_from_headers(headers);
+		const cookies = splitCookiesFromHeaders(headers);
 
 		expect(cookies).toEqual({
 			cookies: [],
@@ -33,7 +33,7 @@ describe('header processing', () => {
 		headers.append('Set-Cookie', `key2=val2; Expires=${exp2}`);
 		headers.append('Set-Cookie', `key3=val3; Expires=${exp3}`);
 
-		const cookies = split_cookies_from_headers(headers);
+		const cookies = splitCookiesFromHeaders(headers);
 
 		expect(cookies).toStrictEqual({
 			headers: {},


### PR DESCRIPTION
This fixes #63, according to local tests with the SWA cli. SvelteKit returns cookies combined together in a single header, so they have to be split apart and parsed into a structure SWA/Azure understands. I haven't tested this in Azure, but if it doesn't work there it's because of the problems mentioned here: https://github.com/Azure/static-web-apps/issues/278