### PR TITLE
Deploy demo to Azure SWA

### DIFF
--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -1,0 +1,45 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+      - deploy-demo
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - deploy-demo
+
+jobs:
+  build_and_deploy_job:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_POLITE_DESERT_00B80111E }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: "upload"
+          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
+          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
+          app_location: "/demo" # App source code path
+          api_location: "demo/api" # Api source code path - optional
+          output_location: "build/static" # Built app content directory - optional
+          ###### End of Repository/Build Configurations ######
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_POLITE_DESERT_00B80111E }}
+          action: "close"

--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -10,6 +10,19 @@ on:
       - main
 
 jobs:
+  clean:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    name: Delete old bot comment
+    steps:
+      - name: pr-deleter
+        uses: maheshrayas/action-pr-comment-delete@06d7254b4aeba4491a66a7e0f755b107f7373ccd
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          org: 'geoffrich'
+          repo: 'svelte-adapter-azure-swa'
+          user: 'github-actions[bot]'
+          issue: '${{github.event.number}}'
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest

--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - deploy-demo
+      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - deploy-demo
+      - main
 
 jobs:
   build_and_deploy_job:
@@ -24,12 +24,12 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_POLITE_DESERT_00B80111E }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          action: "upload"
+          action: 'upload'
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/demo" # App source code path
-          api_location: "demo/api" # Api source code path - optional
-          output_location: "build/static" # Built app content directory - optional
+          app_location: '/demo' # App source code path
+          api_location: 'demo/api' # Api source code path - optional
+          output_location: 'build/static' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
@@ -42,4 +42,4 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_POLITE_DESERT_00B80111E }}
-          action: "close"
+          action: 'close'

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Adapter for Svelte apps that creates an Azure Static Web App, using an Azure function for dynamic server rendering. If your app is purely static, you may be able to use [adapter-static](https://www.npmjs.com/package/@sveltejs/adapter-static) instead.
 
-## Usage
+See the [demo folder](https://github.com/geoffrich/svelte-adapter-azure-swa/tree/main/demo) for an example integration with the SvelteKit demo app. The demo is automatically deployed to [Azure SWA](https://polite-desert-00b80111e.2.azurestaticapps.net/) on every commit to `main`.
 
-See the [demo folder](https://github.com/geoffrich/svelte-adapter-azure-swa/tree/main/demo) for an example integration with the SvelteKit demo app.
+## Usage
 
 Run `npm install -D svelte-adapter-azure-swa`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Adapter for Svelte apps that creates an Azure Static Web App, using an Azure function for dynamic server rendering. If your app is purely static, you may be able to use [adapter-static](https://www.npmjs.com/package/@sveltejs/adapter-static) instead.
 
-See the [demo folder](https://github.com/geoffrich/svelte-adapter-azure-swa/tree/main/demo) for an example integration with the SvelteKit demo app. The demo is automatically deployed to [Azure SWA](https://polite-desert-00b80111e.2.azurestaticapps.net/) on every commit to `main`.
+See the [demo folder](https://github.com/geoffrich/svelte-adapter-azure-swa/tree/main/demo) for an example integration with the SvelteKit demo app. The demo is automatically deployed to [Azure SWA](https://polite-desert-00b80111e.2.azurestaticapps.net/) on every commit to the main branch.
 
 ## Usage
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -4,6 +4,8 @@ This is a repo demonstrating how to use [svelte-adapter-azure-swa](https://www.n
 
 This demo uses the local version of the adapter to make testing unreleased changes easier. In your app, you should install `svelte-adapter-azure-swa` from npm.
 
+[Deployed demo](https://polite-desert-00b80111e.2.azurestaticapps.net/)
+
 ## Developing
 
 Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:

--- a/demo/src/routes/+page.svelte
+++ b/demo/src/routes/+page.svelte
@@ -18,7 +18,7 @@
 			</picture>
 		</span>
 
-		to your new<br />SvelteKit app on Azure SWA
+		to your new<br />SvelteKit app
 	</h1>
 
 	<h2>

--- a/demo/src/routes/+page.svelte
+++ b/demo/src/routes/+page.svelte
@@ -18,7 +18,7 @@
 			</picture>
 		</span>
 
-		to your new<br />SvelteKit app
+		to your new<br />SvelteKit app on Azure SWA
 	</h1>
 
 	<h2>


### PR DESCRIPTION
Closes #79

Deploy the demo app to Azure SWA. This will help us catch build-related bugs since we'll build the demo app with the local adapter as part of the PR.

The Azure SWA workflow is noisy - it creates a new comment on every push - so I added a job that will remove the bot comments before re-deploying.