### PR TITLE
Set `host` in sample `swa-cli.config.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ To run the CLI, install `@azure/static-web-apps-cli` and the [Azure Functions Co
 	"configurations": {
 		"app": {
 			"outputLocation": "./build/static",
-			"apiLocation": "./build/server"
+			"apiLocation": "./build/server",
+			"host": "127.0.0.1"
 		}
 	}
 }


### PR DESCRIPTION
The host option is needed for `swa` to work on systems where `localhost` resolves to the IPv6 loopback address `::1`.  See Azure/static-web-apps-cli#646.