### PR TITLE
Generate CSP headers for prerendered pages

### DIFF
--- a/demo/svelte.config.js
+++ b/demo/svelte.config.js
@@ -3,7 +3,12 @@ import adapter from 'svelte-adapter-azure-swa';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		adapter: adapter(),
+		csp: {
+			directives: {
+				'script-src': ['self']
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
This is just an initial stab at implementing this to start the discussion and see if it is viable. 

From my tests it is working, though not locally with `swa` because of Azure/static-web-apps-cli#646.

For this to be ready for merge, we would need to add
 - [ ] Documentation
 - [ ] Tests

We should discuss if a config option for this should be opt-in or opt-out. If there is no `http-equiv="content-security-policy"` meta tag in a html file, no headers will be generated. I'm not sure there is a usecase where you would want CSP meta tags but not headers?

I entertained the thought of making a PR to SvelteKit for exposing any headers returned for pages during pre-rendering in `builder.prerendered` to the adapters, but I think this solution here is a better first step.

What do you think , @geoffrich?