### PR TITLE
ci: work around npm cache issue

### DIFF
--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -27,14 +27,13 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.repository == 'geoffrich/svelte-adapter-azure-swa' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      # workaround for Oryx issue: see https://github.com/Azure/static-web-apps/issues/909#issuecomment-1320077142
+      CUSTOM_BUILD_COMMAND: 'chown -R root:root . && npm install --unsafe-perm && npm run build'
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      # attempt to fix persistent npm error: "Your cache folder contains root-owned files, due to a bug in previous versions of npm which has since been addressed."
-      - name: fix cache issue
-        run: |
-          sudo chown -R 1001:123 "/github/home/.npm" | :
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      # attempt to fix persistent npm error: "Your cache folder contains root-owned files, due to a bug in previous versions of npm which has since been addressed."
+      - name: fix cache issue
+        run: sudo chown -Rf 1001:123 "/github/home/.npm"
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -33,7 +33,8 @@ jobs:
           submodules: true
       # attempt to fix persistent npm error: "Your cache folder contains root-owned files, due to a bug in previous versions of npm which has since been addressed."
       - name: fix cache issue
-        run: sudo chown -Rf 1001:123 "/github/home/.npm"
+        run: |
+          sudo chown -R 1001:123 "/github/home/.npm" | :
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -27,9 +27,6 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.repository == 'geoffrich/svelte-adapter-azure-swa' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
-    env:
-      # workaround for Oryx issue: see https://github.com/Azure/static-web-apps/issues/909#issuecomment-1320077142
-      CUSTOM_BUILD_COMMAND: 'chown -R root:root . && npm install --unsafe-perm && npm run build'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -46,6 +43,8 @@ jobs:
           app_location: '/demo' # App source code path
           api_location: 'demo/build/server' # Api source code path - optional
           output_location: 'build/static' # Built app content directory - optional
+          # workaround for Oryx issue: see https://github.com/Azure/static-web-apps/issues/909#issuecomment-1320077142
+          app_build_command: 'chown -R root:root . && npm install --unsafe-perm && npm run build'
           ###### End of Repository/Build Configurations ######
     outputs:
       preview_url: ${{ steps.builddeploy.outputs.static_web_app_url }}

--- a/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-desert-00b80111e.yml
@@ -27,6 +27,9 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.repository == 'geoffrich/svelte-adapter-azure-swa' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      # workaround for Oryx issue: see https://github.com/Azure/static-web-apps/issues/909#issuecomment-1320077142
+      CUSTOM_BUILD_COMMAND: 'chown -R root:root . && npm install --unsafe-perm && npm run build'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -43,8 +46,8 @@ jobs:
           app_location: '/demo' # App source code path
           api_location: 'demo/build/server' # Api source code path - optional
           output_location: 'build/static' # Built app content directory - optional
-          # workaround for Oryx issue: see https://github.com/Azure/static-web-apps/issues/909#issuecomment-1320077142
-          app_build_command: 'chown -R root:root . && npm install --unsafe-perm && npm run build'
+          # needed when we set CUSTOM_BUILD_COMMAND
+          skip_api_build: true
           ###### End of Repository/Build Configurations ######
     outputs:
       preview_url: ${{ steps.builddeploy.outputs.static_web_app_url }}


### PR DESCRIPTION
This fixes a persistent npm error when running `prepare` in the demo app: 

```
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /github/home/.npm/_cacache/index-v5/ca/7e
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1001:123 "/github/home/.npm"

npm ERR! A complete log of this run can be found in:
npm ERR!     /github/home/.npm/_logs/2023-03-11T20_07_27_602Z-debug-0.log
npm ERR! code 243
npm ERR! path /github/workspace/demo
npm ERR! command failed
npm ERR! command sh -c -- cd .. && npm i

npm ERR! A complete log of this run can be found in:
npm ERR!     /github/home/.npm/_logs/2023-03-11T20_07_22_826Z-debug-0.log
```

This applies the fix from https://github.com/Azure/static-web-apps/issues/909#issuecomment-1320077142 (which was supposedly only need for ADO pipelines, but whatever). Theoretically we can remove the workaround once SWA's version of Oryx is updated.