### PR TITLE
fix: binary body is incorrectly parsed as UTF-8

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -70,7 +70,11 @@ function toRequest(context) {
 	};
 
 	if (method !== 'GET' && method !== 'HEAD') {
-		init.body = Buffer.isBuffer(body) ? body : typeof rawBody === 'string' ? Buffer.from(rawBody, 'utf-8') : rawBody;
+		init.body = Buffer.isBuffer(body)
+			? body
+			: typeof rawBody === 'string'
+			? Buffer.from(rawBody, 'utf-8')
+			: rawBody;
 	}
 
 	return new Request(originalUrl, init);

--- a/files/entry.js
+++ b/files/entry.js
@@ -58,7 +58,7 @@ export async function index(context) {
  * @returns {Request}
  * */
 function toRequest(context) {
-	const { method, headers, rawBody: body } = context.req;
+	const { method, headers, rawBody, body } = context.req;
 	// because we proxy all requests to the render function, the original URL in the request is /api/__render
 	// this header contains the URL the user requested
 	const originalUrl = headers['x-ms-original-url'];
@@ -70,7 +70,7 @@ function toRequest(context) {
 	};
 
 	if (method !== 'GET' && method !== 'HEAD') {
-		init.body = typeof body === 'string' ? Buffer.from(body, 'utf-8') : body;
+		init.body = Buffer.isBuffer(body) ? body : typeof rawBody === 'string' ? Buffer.from(rawBody, 'utf-8') : rawBody;
 	}
 
 	return new Request(originalUrl, init);


### PR DESCRIPTION
When the request body contains binary data it gets parsed incorrectly, leading to corrupted data.

According to https://github.com/Azure/azure-functions-nodejs-library/blob/752fd223518fb53c217d5929d5933df0ad061d49/types/http.d.ts#L92-L98 the body property already contains a Buffer for certain media types, so there's no need to create a new one from the rawBody anyway.