### PR TITLE
feat: add context to the platform object

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,7 @@ To get typings for the `platform` property, reference this adapter in your `src/
 This contains the client principal as parsed from the `x-ms-client-principal` request header. See the [official SWA documentation](https://learn.microsoft.com/en-us/azure/static-web-apps/user-information?tabs=javascript#api-functions) or [the types](index.d.ts) for further details.
 
 This is currently only available when running in production on SWA. In addition, it is only available in certain circumstances in production - see [this adapter issue](https://github.com/geoffrich/svelte-adapter-azure-swa/issues/102) for more details. Please report any issues you encounter.
+
+### `context`
+
+All server requests to your SvelteKit app are handled by an Azure function. This property contains that Azure function's [request context](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node#context-object).

--- a/files/entry.js
+++ b/files/entry.js
@@ -40,7 +40,8 @@ export async function index(context) {
 			return ipAddress;
 		},
 		platform: {
-			clientPrincipal
+			clientPrincipal,
+			context
 		}
 	});
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { Adapter } from '@sveltejs/kit';
 import { ClientPrincipal, CustomStaticWebAppConfig } from './types/swa';
+import { Context } from '@azure/functions';
 import esbuild from 'esbuild';
 
 export * from './types/swa';
@@ -28,7 +29,14 @@ declare global {
 			 *
 			 * @see The {@link https://learn.microsoft.com/en-us/azure/static-web-apps/user-information?tabs=javascript#api-functions SWA documentation}
 			 */
+
+			/**
+			 * The Azure function request context.
+			 *
+			 * @see The {@link https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node#context-object Azure function documentation}
+			 */
 			clientPrincipal?: ClientPrincipal;
+			context: Context;
 		}
 	}
 }


### PR DESCRIPTION
Closes #126 
Related #30 

This PR adds the Azure function [context](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node#context-object) to the platform exposed by the adapter.