### PR TITLE
fix: await server init

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -14,7 +14,7 @@ const debug = DEBUG;
 installPolyfills();
 
 const server = new Server(manifest);
-server.init({ env: process.env });
+const initialized = server.init({ env: process.env });
 
 /**
  * @typedef {import('@azure/functions').AzureFunction} AzureFunction
@@ -35,6 +35,7 @@ export async function index(context) {
 	const ipAddress = getClientIPFromHeaders(request.headers);
 	const clientPrincipal = getClientPrincipalFromHeaders(request.headers);
 
+	await initialized;
 	const rendered = await server.respond(request, {
 		getClientAddress() {
 			return ipAddress;


### PR DESCRIPTION
Closes #62 
Alternative to #72

Instead of top-level await, I opted to await before handling any requests. Not sure if Azure functions support top-level await, but either way it's probably best to check right before we need it.

This is similar to the [adapter-vercel](https://github.com/sveltejs/kit/blob/b2dbbdfcb2bf178337080bbe4a964f67b304c2ab/packages/adapter-vercel/files/edge.js#L14) implementation.