### PR TITLE
feat: allow overriding `platform.apiRuntime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ export default {
 						'redirect': '/login',
 						'statusCode': 302
 					}
+				},
+				platform: {
+					apiRuntime: 'node:18'
 				}
 			}
 		})

--- a/demo/svelte.config.js
+++ b/demo/svelte.config.js
@@ -3,13 +3,7 @@ import adapter from 'svelte-adapter-azure-swa';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter({
-			customStaticWebAppConfig: {
-				platform: {
-					apiRuntime: 'node:18'
-				}
-			}
-		})
+		adapter: adapter()
 	}
 };
 

--- a/demo/svelte.config.js
+++ b/demo/svelte.config.js
@@ -3,7 +3,13 @@ import adapter from 'svelte-adapter-azure-swa';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		adapter: adapter({
+			customStaticWebAppConfig: {
+				platform: {
+					apiRuntime: 'node:18'
+				}
+			}
+		})
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -210,7 +210,8 @@ export function generateConfig(customStaticWebAppConfig, appDir) {
 			rewrite: ssrFunctionRoute
 		},
 		platform: {
-			apiRuntime: 'node:16'
+			apiRuntime: 'node:16',
+			...customStaticWebAppConfig.platform
 		}
 	};
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,9 +53,13 @@ describe('generateConfig', () => {
 
 	test('accepts custom config', () => {
 		const result = generateConfig({
+			platform: {
+				apiRuntime: 'node:18'
+			},
 			globalHeaders: { 'X-Foo': 'bar' }
 		});
 		expect(result.globalHeaders).toStrictEqual({ 'X-Foo': 'bar' });
+		expect(result.platform.apiRuntime).toBe('node:18');
 	});
 });
 


### PR DESCRIPTION
Closes #48 

Instead of introducing a separate config option to set a custom node version, this PR allows setting `platform.apiRuntime` via `customStaticWebAppConfig`

e.g.

```js
// svelte.config.js
import adapter from 'svelte-adapter-azure-swa';

/** @type {import('@sveltejs/kit').Config} */
const config = {
	kit: {
		adapter: adapter({
			customStaticWebAppConfig: {
				platform: {
					apiRuntime: 'node:18'
				}
			}
		})
	}
};

export default config;
```