### PR TITLE
Update demo with login/logout

### DIFF
--- a/demo/src/routes/+layout.server.js
+++ b/demo/src/routes/+layout.server.js
@@ -1,0 +1,5 @@
+export const load = ({ platform }) => {
+	return {
+		clientPrincipal: platform?.clientPrincipal
+	};
+};

--- a/demo/src/routes/+layout.svelte
+++ b/demo/src/routes/+layout.svelte
@@ -1,12 +1,17 @@
 <script>
 	import Header from './Header.svelte';
 	import './styles.css';
+
+	export let data;
 </script>
 
 <div class="app">
-	<Header />
+	<Header isLoggedIn={!!data.clientPrincipal} />
 
 	<main>
+		{#if data.clientPrincipal}
+			<p>{JSON.stringify(data.clientPrincipal)}</p>
+		{/if}
 		<slot />
 	</main>
 

--- a/demo/src/routes/+page.js
+++ b/demo/src/routes/+page.js
@@ -1,3 +1,0 @@
-// since there's no dynamic data here, we can prerender
-// it so that it gets served as a static asset in production
-export const prerender = true;

--- a/demo/src/routes/Header.svelte
+++ b/demo/src/routes/Header.svelte
@@ -2,6 +2,8 @@
 	import { page } from '$app/stores';
 	import logo from '$lib/images/svelte-logo.svg';
 	import github from '$lib/images/github.svg';
+
+	export let isLoggedIn = false;
 </script>
 
 <header>
@@ -25,6 +27,15 @@
 			<li aria-current={$page.url.pathname.startsWith('/sverdle') ? 'page' : undefined}>
 				<a href="/sverdle">Sverdle</a>
 			</li>
+			{#if isLoggedIn}
+				<li>
+					<a href="/.auth/logout" data-sveltekit-reload>Logout</a>
+				</li>
+			{:else}
+				<li>
+					<a href="/.auth/login/github" data-sveltekit-reload>Login</a>
+				</li>
+			{/if}
 		</ul>
 		<svg viewBox="0 0 2 3" aria-hidden="true">
 			<path d="M0,0 L0,3 C0.5,3 0.5,3 1,2 L2,0 Z" />

--- a/demo/src/routes/about/+page.js
+++ b/demo/src/routes/about/+page.js
@@ -3,7 +3,3 @@ import { dev } from '$app/environment';
 // we don't need any JS on this page, though we'll load
 // it in dev so that we get hot module replacement
 export const csr = dev;
-
-// since there's no dynamic data here, we can prerender
-// it so that it gets served as a static asset in production
-export const prerender = true;

--- a/demo/src/routes/sverdle/how-to-play/+page.js
+++ b/demo/src/routes/sverdle/how-to-play/+page.js
@@ -1,9 +1,0 @@
-import { dev } from '$app/environment';
-
-// we don't need any JS on this page, though we'll load
-// it in dev so that we get hot module replacement
-export const csr = dev;
-
-// since there's no dynamic data here, we can prerender
-// it so that it gets served as a static asset in production
-export const prerender = true;


### PR DESCRIPTION
Closes #102 [ WIP ]

- [ ] Add "User" page to demo that can only be accessed when logged in. Redirect to login page if accessed when not logged in.
- [ ] Figure out local auth setup - will need to downgrade SWA CLI version to 1.1.3 for testing
- [ ] Documentation
  - [ ] Using `platform.clientPrincipal` in load functions to protect routes (or deriving `locals` value from it)
  - [ ] Linking to login/logout pages (applying `data-sveltekit-reload`)
  - [ ] Displaying the logged-in user info
  - [ ] Document local auth setup
  - [ ] Caveat: does not work for prerendered pages
  - [ ] Note that config-based setup not fully compatible, link route-level config issue
  - [ ] Remove existing docs caveat about `clientPrincipal` only something being available