### PR TITLE
feat: add `loader` to `esbuildOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ export default {
 
 ### esbuildOptions
 
-An object containing additional [esbuild options](https://esbuild.github.io/api/#build-api). Currently only supports [external](https://esbuild.github.io/api/#external) and [keepNames](https://esbuild.github.io/api/#keep-names). If you require additional options to be exposed, please [open an issue](https://github.com/geoffrich/svelte-adapter-azure-swa/issues).
+An object containing additional [esbuild options](https://esbuild.github.io/api/#build-api). Currently only supports [external](https://esbuild.github.io/api/#external), [keepNames](https://esbuild.github.io/api/#keep-names), and [loader](https://esbuild.github.io/api/#loader). If you require additional options to be exposed, please [open an issue](https://github.com/geoffrich/svelte-adapter-azure-swa/issues).
 
 ```js
 import azure from 'svelte-adapter-azure-swa';

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export * from './types/swa';
 export type Options = {
 	debug?: boolean;
 	customStaticWebAppConfig?: CustomStaticWebAppConfig;
-	esbuildOptions?: Pick<esbuild.BuildOptions, 'external' | 'keepNames'>;
+	esbuildOptions?: Pick<esbuild.BuildOptions, 'external' | 'keepNames' | 'loader'>;
 	apiDir?: string;
 	staticDir?: string;
 	allowReservedSwaRoutes?: boolean;

--- a/index.js
+++ b/index.js
@@ -132,7 +132,8 @@ If you want to suppress this error, set allowReservedSwaRoutes to true in your a
 				target: 'node16',
 				sourcemap: 'linked',
 				external: esbuildOptions.external,
-				keepNames: esbuildOptions.keepNames
+				keepNames: esbuildOptions.keepNames,
+				loader: esbuildOptions.loader
 			};
 
 			await esbuild.build(default_options);


### PR DESCRIPTION
Closes #147

Can be used with the following svelte.config.js:

```js
import azure from 'svelte-adapter-azure-swa';

export default {
	kit: {
		...
		adapter: azure({
			esbuildOptions: {
				loader: {
					'.node': 'copy'
				}
			}
		})
	}
};
```