### PR TITLE
fix: do not throw on parsing client principal

### DIFF
--- a/files/headers.js
+++ b/files/headers.js
@@ -54,9 +54,14 @@ export function getClientPrincipalFromHeaders(headers) {
 		return undefined;
 	}
 
-	const encoded = Buffer.from(header, 'base64');
-	const decoded = encoded.toString('ascii');
-	const clientPrincipal = JSON.parse(decoded);
+	try {
+		const encoded = Buffer.from(header, 'base64');
+		const decoded = encoded.toString('ascii');
+		const clientPrincipal = JSON.parse(decoded);
 
-	return clientPrincipal;
+		return clientPrincipal;
+	} catch (e) {
+		console.log('Unable to parse client principal:', e);
+		return undefined;
+	}
 }

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -118,4 +118,12 @@ describe('client principal parsing', () => {
 	test('returns undefined when there is no client principal', () => {
 		expect(getClientPrincipalFromHeaders(new Headers())).toBeUndefined();
 	});
+
+	test('returns undefined if unable to parse', () => {
+		const headers = new Headers({
+			'x-ms-client-principal': 'boom'
+		});
+
+		expect(getClientPrincipalFromHeaders(headers)).toBeUndefined();
+	});
 });


### PR DESCRIPTION
Related https://github.com/geoffrich/svelte-adapter-azure-swa/issues/157

With this PR, we won't throw if the parsed client principal can't be decoded as JSON. We'll return undefined instead.

The underlying issue linked above still needs to be fixed, however.