### PR TITLE
Add missing content-type header for empty POST requests

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -29,6 +29,12 @@ export async function index(context) {
 	const request = toRequest(context);
 
 	if (debug) {
+		context.log(
+			'Starting request',
+			context?.req?.method,
+			context?.req?.headers?.['x-ms-original-url']
+		);
+		context.log(`Original request: ${JSON.stringify(context)}`);
 		context.log(`Request: ${JSON.stringify(request)}`);
 	}
 

--- a/files/entry.js
+++ b/files/entry.js
@@ -66,6 +66,12 @@ function toRequest(context) {
 	// this header contains the URL the user requested
 	const originalUrl = headers['x-ms-original-url'];
 
+	// SWA strips content-type headers from empty POST requests, but SK form actions require the header
+	// https://github.com/geoffrich/svelte-adapter-azure-swa/issues/178
+	if (method === 'POST' && !body && !headers['content-type']) {
+		headers['content-type'] = 'application/x-www-form-urlencoded';
+	}
+
 	/** @type {RequestInit} */
 	const init = {
 		method,


### PR DESCRIPTION
Closes https://github.com/geoffrich/svelte-adapter-azure-swa/issues/178

Azure functions seem to strip the content-type header from empty POST requests, but SvelteKit requires it. Add it back before sending the request to SK.

More details: https://github.com/geoffrich/svelte-adapter-azure-swa/issues/178#issuecomment-2212849832